### PR TITLE
Patch name typo in app.json.

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-    "name": "Timetrap",
+    "name": "Timestrap",
     "description": "Time tracking and invoicing you can host anywhere. Full export support in multiple formats and easily extensible.",
     "repository": "https://github.com/overshard/timestrap",
     "keywords": ["python", "django"],


### PR DESCRIPTION
Was browsing your project since it showed up in my github "trending repositories" digest email. Noticed this typo and couldn't help patching it. Never know that Heroku had that deploy with template feature. Neat!