### PR TITLE
Refactor Selenium tests for smaller methods.

### DIFF
--- a/timesheets/tests/tests_selenium.py
+++ b/timesheets/tests/tests_selenium.py
@@ -18,7 +18,9 @@ from easyprocess import EasyProcessCheckInstalledError
 
 from faker import Factory
 
-from ..models import Client, Project
+from datetime import timedelta
+
+from ..models import Client, Project, Entry
 
 
 fake = Factory.create()
@@ -59,6 +61,11 @@ class SeleniumTests(StaticLiveServerTestCase):
         else:
             return elements
 
+    def addPerms(self, perms):
+        for codename in perms:
+            self.user.user_permissions.add(
+                Permission.objects.get(codename=codename))
+
     def waitForPresence(self, element):
         return WebDriverWait(self.selenium, self.wait_time).until(
             ec.presence_of_element_located(element))
@@ -82,9 +89,8 @@ class SeleniumTests(StaticLiveServerTestCase):
         self.find(By.NAME, 'login').click()
         self.waitForPresence((By.ID, 'view-dashboard'))
 
-    def test_login(self):
+    def test_login_failure(self):
         self.selenium.get('%s%s' % (self.live_server_url, '/login/'))
-
         username_input = self.find(By.NAME, 'username')
         username_input.send_keys(self.profile['username'])
         password_input = self.find(By.NAME, 'password')
@@ -93,33 +99,37 @@ class SeleniumTests(StaticLiveServerTestCase):
         # Log in failure creates an alert notice.
         self.waitForPresence((By.CSS_SELECTOR, '.alert.alert-danger'))
 
+    def test_clients_access(self):
         self.logIn()
-
-    def test_clients(self):
-        self.logIn()
-
         self.assertNotIn('Clients', self.find(By.ID, 'navbarNav').text)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='view_client'))
+        self.addPerms(['view_client'])
         self.selenium.get(self.live_server_url)
         self.find(By.CSS_SELECTOR, 'a[href="/clients/"]').click()
         self.waitForPresence((By.ID, 'view-clients'))
 
+    def test_clients_add(self):
+        self.logIn()
+        self.addPerms(['view_client', 'add_client'])
+        self.selenium.get('%s%s' % (self.live_server_url, '/clients/'))
+
         # The <clients> tag only has two elements when there is no add form.
         self.assertEqual(len(self.find(By.CSS_SELECTOR, 'clients > *')), 2)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='add_client'))
         self.selenium.refresh()
         self.find(By.NAME, 'client-name').send_keys('Client')
         self.find(By.CSS_SELECTOR,
                   'form[name="client-add"] button[type="submit"]').click()
         self.waitForText((By.CSS_SELECTOR, 'client:first-of-type'), 'Client')
 
+    def test_clients_change(self):
+        Client(name='Client', archive=False).save()
+        self.logIn()
+        self.addPerms(['view_client'])
+        self.selenium.get('%s%s' % (self.live_server_url, '/clients/'))
+
         # The client edit button should be disabled for unprivileged users.
         self.assertIsInstance(self.find(
             By.CSS_SELECTOR, 'client button:disabled'), FirefoxWebElement)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='change_client'))
+        self.addPerms(['change_client'])
         self.selenium.refresh()
         self.find(By.CSS_SELECTOR, 'client button').click()
         self.waitForPresence((By.CSS_SELECTOR, 'client input'))
@@ -128,71 +138,93 @@ class SeleniumTests(StaticLiveServerTestCase):
         self.waitForText((By.CSS_SELECTOR, 'client:first-of-type'),
                          'Client Changed')
 
+    def test_projects_access(self):
+        Client(name='Client', archive=False).save()
+        self.logIn()
+        self.addPerms(['view_client'])
+        self.selenium.get('%s%s' % (self.live_server_url, '/clients/'))
+
         # If Projects are not viewable, the client name will be in a <span>
         # instead of an <a>.
         self.assertIsInstance(self.find(
             By.CSS_SELECTOR, 'client span.text-primary'), FirefoxWebElement)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='view_project'))
+        self.addPerms(['view_project'])
         self.selenium.refresh()
         self.find(By.CSS_SELECTOR, 'client a.text-primary')
+
+    def test_projects_add(self):
+        Client(name='Client', archive=False).save()
+        self.logIn()
+        self.addPerms(['view_client', 'view_project'])
+        self.selenium.get('%s%s' % (self.live_server_url, '/clients/'))
 
         # The <client> tag only has two elements when there is no Project add
         # form.
         self.assertEqual(len(self.find(By.CSS_SELECTOR, 'client > *')), 2)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='add_project'))
+        self.addPerms(['add_project'])
         self.selenium.refresh()
         self.find(By.CSS_SELECTOR, 'client i.fa-chevron-circle-down').click()
         self.waitForPresence((By.NAME, 'project-name'))
         self.find(By.NAME, 'project-name').send_keys('Project')
         self.find(By.CSS_SELECTOR,
+                  'client form input[placeholder="Estimate"').send_keys('1')
+        self.find(By.CSS_SELECTOR,
                   'form[name="project-add"] button[type="submit"]').click()
         self.waitForText((By.CSS_SELECTOR, 'client project'), 'Project')
+
+    def test_projects_change(self):
+        client = Client(name='Client', archive=False)
+        client.save()
+        Project(name='Project', client=client, estimate=timedelta(hours=1),
+                archive=False).save()
+        self.logIn()
+        self.addPerms(['view_client', 'view_project'])
+        self.selenium.get('%s%s' % (self.live_server_url, '/clients/'))
 
         # The project edit button should be disabled for unprivileged users.
         self.assertIsInstance(self.find(
             By.CSS_SELECTOR, 'project button:disabled'), FirefoxWebElement)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='change_project'))
+        self.addPerms(['change_project'])
         self.selenium.refresh()
         self.find(By.CSS_SELECTOR, 'client i.fa-chevron-circle-down').click()
         self.waitForPresence((By.CSS_SELECTOR, 'project button'))
         self.find(By.CSS_SELECTOR, 'project button').click()
         self.waitForPresence((By.CSS_SELECTOR, 'project input'))
-        self.find(By.CSS_SELECTOR, 'project input').send_keys(' Changed')
+        self.find(By.CSS_SELECTOR,
+                  'project input[value="Project"]').send_keys(' Changed')
+        self.find(By.CSS_SELECTOR, 'project input[value="1"]').send_keys('.5')
         self.find(By.CSS_SELECTOR, 'project button').click()
         self.waitForText((By.CSS_SELECTOR, 'project:first-of-type'),
                          'Project Changed')
 
-    def test_entries(self):
+    def test_entries_access(self):
         self.logIn()
 
         self.assertNotIn('Entries', self.find(By.ID, 'navbarNav').text)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='view_entry'))
+        self.addPerms(['view_entry'])
         self.selenium.get(self.live_server_url)
         self.find(By.CSS_SELECTOR, 'a[href="/entries/"]').click()
         self.waitForPresence((By.ID, 'view-entries'))
 
-        client = Client(name="Client", archive=False)
+    def test_entries_add(self):
+        client = Client(name='Client', archive=False)
         client.save()
-        project = Project(name="Project 1", client=client, archive=False)
-        project.save()
-        project = Project(name="Project 2", client=client, archive=False)
-        project.save()
+        Project(name='Project 1', estimate=timedelta(hours=1), client=client,
+                archive=False).save()
+        Project(name='Project 2', estimate=timedelta(hours=1), client=client,
+                archive=False).save()
+        self.logIn()
+        self.addPerms(['view_client', 'view_project', 'view_entry'])
+        self.selenium.get('%s%s' % (self.live_server_url, '/entries/'))
 
         # The <entries> tag only has three elements when there is no add form.
         self.assertEqual(len(self.find(By.CSS_SELECTOR, 'entries > *')), 3)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='add_entry'),
-            Permission.objects.get(codename='view_client'),
-            Permission.objects.get(codename='view_project'))
+        self.addPerms(['add_entry'])
         self.selenium.refresh()
         self.find(By.CLASS_NAME, 'select2-selection__arrow').click()
         self.waitForPresence((By.CLASS_NAME, 'select2-search__field'))
         self.find(By.CLASS_NAME,
-                  'select2-search__field').send_keys('Project 2')
+                  'select2-search__field').send_keys('Project 1')
         self.find(By.CLASS_NAME,
                   'select2-search__field').send_keys(Keys.RETURN)
         self.find(By.CSS_SELECTOR,
@@ -202,12 +234,26 @@ class SeleniumTests(StaticLiveServerTestCase):
         self.find(By.CSS_SELECTOR,
                   'entries form button[type="submit"]').submit()
         self.waitForText((By.CSS_SELECTOR, 'entry'),
-                         'Client\nProject 2\nNote\n0:35')
+                         'Client\nProject 1\nNote\n0:35')
+
+    def test_entries_change(self):
+        client = Client(name='Client', archive=False)
+        client.save()
+        project = Project(name='Project 1', estimate=timedelta(hours=1),
+                          client=client, archive=False)
+        project.save()
+        Project(name='Project 2', estimate=timedelta(hours=1), client=client,
+                archive=False).save()
+        # Log in first to establish self.user.
+        self.logIn()
+        Entry(project=project, user=self.user, note='Note',
+              duration=timedelta(minutes=35)).save()
+        self.addPerms(['view_client', 'view_project', 'view_entry'])
+        self.selenium.get('%s%s' % (self.live_server_url, '/entries/'))
 
         # The <entry> tag does not have an Edit button.
         self.assertNotIn('Edit', self.find(By.CSS_SELECTOR, 'entry').text)
-        self.user.user_permissions.add(
-            Permission.objects.get(codename='change_entry'))
+        self.addPerms(['change_entry'])
         self.selenium.refresh()
         self.find(By.ID, 'entry-edit-menu').click()
         # The second entry is the "Edit" link option. For some reason there are
@@ -221,7 +267,7 @@ class SeleniumTests(StaticLiveServerTestCase):
         self.find(By.CSS_SELECTOR, 'entry .select2-selection__arrow').click()
         self.waitForPresence((By.CLASS_NAME, 'select2-search__field'))
         self.find(By.CLASS_NAME,
-                  'select2-search__field').send_keys('Project 1')
+                  'select2-search__field').send_keys('Project 2')
         self.find(By.CLASS_NAME,
                   'select2-search__field').send_keys(Keys.RETURN)
         self.find(By.CSS_SELECTOR, 'entry input[value="Note"]').clear()
@@ -232,10 +278,10 @@ class SeleniumTests(StaticLiveServerTestCase):
                   'entry input[value="0:35"]').send_keys('1.5')
         self.find(By.CSS_SELECTOR, 'entry button').click()
         self.selenium.refresh()
-        self.assertIn('Client\nProject 1\nChanged note\n1:30',
+        self.assertIn('Client\nProject 2\nChanged note\n1:30',
                       self.find(By.CSS_SELECTOR, 'entry').text)
 
-    def test_reports(self):
+    def test_reports_access(self):
         self.logIn()
 
         self.find(By.CSS_SELECTOR, 'a[href="/reports/"]').click()


### PR DESCRIPTION
Snuck this in over lunch (:

**Note**: This change seems to exacerbate the "Broken pipe" or "Connection aborted" issue that causes failures in CI (and sometime locally). I found that each test run individually succeeds seemingly every time, but when they are all run as a group there is almost always at least one failure. I wasn't able to take the time to research much, but it seems to have something to do with Selenium making a bunch of requests in succession.