### PR TITLE
Selenium tests tweaks

### DIFF
--- a/core/tests/tests_selenium.py
+++ b/core/tests/tests_selenium.py
@@ -48,6 +48,14 @@ class SeleniumTestCase(StaticLiveServerTestCase):
                 'browserName': 'chrome',
                 'version': '58',
                 'platform': 'ANY',
+                'chromeOptions': {
+                    'prefs': {
+                        'credentials_enable_service': False,
+                        'profile': {
+                            'password_manager_enabled': False
+                        }
+                    }
+                }
             }
             if os.environ.get('TRAVIS_JOB_NUMBER', None):
                 desired_capabilities.update({

--- a/core/tests/tests_selenium.py
+++ b/core/tests/tests_selenium.py
@@ -280,6 +280,7 @@ class SeleniumTestCase(StaticLiveServerTestCase):
         self.find(By.NAME, 'task-change').click()
         self.waitForPresence((By.NAME, 'task-name'))
         self.find(By.NAME, 'task-name').send_keys(' Changed')
+        self.find(By.NAME, 'task-hourly-rate').click()
         self.find(By.NAME, 'task-hourly-rate').clear()
         self.find(By.NAME, 'task-hourly-rate').send_keys('125')
         self.find(By.NAME, 'task-save').click()

--- a/timestrap/static_src/components/app.vue
+++ b/timestrap/static_src/components/app.vue
@@ -26,7 +26,7 @@
                         </router-link>
                     </li>
                     <li class="nav-item">
-                        <router-link class="nav-link" :to="reports">
+                        <router-link id="nav-app-reports" class="nav-link" :to="reports">
                             <i class="fa fa-book mr-1" aria-hidden="true"></i>
                             Reports
                         </router-link>

--- a/timestrap/static_src/components/entry.vue
+++ b/timestrap/static_src/components/entry.vue
@@ -125,9 +125,13 @@ export default {
         deleteEntry() {
             quickFetch(this.url, 'delete').then(function(response) {
                 if (response.status === 204) {
+                    $.growl.notice({ message: 'Entry deleted!' });
+                    this.$emit('delete-entry');
                 }
-            });
-            this.$emit('delete-entry');
+                else {
+                    $.growl.error({ message: 'Entry delete failed ):' });
+                }
+            }.bind(this));
         },
         projectSelect(project) {
             this.project = project;


### PR DESCRIPTION
Ran the tests through Sauce Labs and made a few small changes. The only currently failing tests are `test_reports_filter` and `test_timesheet_entry_restart`, as expected. Those two tests will likely need to be updated once the functionality is ported to Vue.