### PR TITLE
Replace remaining utils.js functions with DurationFormatter mixin

### DIFF
--- a/gulpfile.js/tasks/linting.js
+++ b/gulpfile.js/tasks/linting.js
@@ -48,7 +48,6 @@ gulp.task('lint:sass', function() {
 gulp.task('lint:es', function() {
     return gulp.src([
         'gulpfile.js/**/*.js',
-        'timestrap/static_src/scripts/**/*.js',
         'timestrap/static_src/app.js',
         'timestrap/static_src/components/**/*.vue'])
         .pipe(eslint({

--- a/gulpfile.js/tasks/linting.js
+++ b/gulpfile.js/tasks/linting.js
@@ -49,7 +49,9 @@ gulp.task('lint:es', function() {
     return gulp.src([
         'gulpfile.js/**/*.js',
         'timestrap/static_src/app.js',
-        'timestrap/static_src/components/**/*.vue'])
+        'timestrap/static_src/components/**/*.vue',
+        'timestrap/static_src/mixins/**/*.js',
+        'timestrap/static_src/plugins/**/*.js',])
         .pipe(eslint({
             'rules': {
                 'indent': [

--- a/gulpfile.js/tasks/scripts.js
+++ b/gulpfile.js/tasks/scripts.js
@@ -21,8 +21,7 @@ gulp.task('scripts:vendor', function(){
         'node_modules/pickadate/lib/compressed/picker.js',
         'node_modules/pickadate/lib/compressed/picker.date.js',
         'node_modules/js-cookie/src/js.cookie.js',
-        'node_modules/jquery.growl/javascripts/jquery.growl.js',
-        'timestrap/static_src/scripts/**/*.js'])
+        'node_modules/jquery.growl/javascripts/jquery.growl.js'])
         .pipe(concat('bundle-vendor.js'))
         .pipe(gulp.dest('timestrap/static/js/'));
 });

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -3,7 +3,6 @@ const gulp = require('gulp');
 
 gulp.task('watch', [
     'watch:sass',
-    'watch:scripts',
     'watch:app',
     'watch:components',
     'watch:plugins',
@@ -12,11 +11,6 @@ gulp.task('watch', [
 
 gulp.task('watch:sass', function() {
     return gulp.watch('timestrap/static_src/sass/**/*.scss', ['styles:sass']);
-});
-
-
-gulp.task('watch:scripts', function() {
-    return gulp.watch('timestrap/static_src/scripts/**/*.js', ['scripts:vendor']);
 });
 
 

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -1,7 +1,13 @@
 const gulp = require('gulp');
 
 
-gulp.task('watch', ['watch:sass', 'watch:scripts', 'watch:app', 'watch:components', 'watch:plugins']);
+gulp.task('watch', [
+    'watch:sass',
+    'watch:scripts',
+    'watch:app',
+    'watch:components',
+    'watch:plugins',
+    'watch:mixins']);
 
 
 gulp.task('watch:sass', function() {
@@ -25,4 +31,8 @@ gulp.task('watch:components', function() {
 
 gulp.task('watch:plugins', function() {
     return gulp.watch('timestrap/static_src/plugins/**/*.js', ['scripts:app']);
+});
+
+gulp.task('watch:mixins', function() {
+    return gulp.watch('timestrap/static_src/mixins/**/*.js', ['scripts:app']);
 });

--- a/timestrap/static_src/components/entry.vue
+++ b/timestrap/static_src/components/entry.vue
@@ -97,10 +97,12 @@
 
 
 <script>
+const DurationFormatter = require('../mixins/durationformatter');
 const Select2 = require('./select2.vue');
 
 export default {
     props: ['entry', 'editable'],
+    mixins: [ DurationFormatter ],
     data() {
         return {
             edit: false,
@@ -111,7 +113,7 @@ export default {
             task: this.entry.task,
             task_details: this.entry.task_details,
             note: this.entry.note,
-            duration: durationToString(this.entry.duration),
+            duration: this.durationToString(this.entry.duration),
             projects: {}
         };
     },
@@ -141,7 +143,7 @@ export default {
                     this.project_details = data.project_details;
                     this.task = data.task;
                     this.task_details = data.task_details;
-                    this.duration = durationToString(data.duration);
+                    this.duration = this.durationToString(data.duration);
                 }
             }).catch(error => console.log(error));
         },

--- a/timestrap/static_src/components/reports.vue
+++ b/timestrap/static_src/components/reports.vue
@@ -140,11 +140,13 @@
 
 <script>
 const Datepicker = require('./datepicker.vue');
+const DurationFormatter = require('../mixins/durationformatter');
 const Entry = require('./entry.vue');
 const Pager = require('./pager.vue');
 const Select2 = require('./select2.vue');
 
 export default {
+    mixins: [ DurationFormatter ],
     data() {
         return {
             entries: null,
@@ -208,8 +210,8 @@ export default {
                     });
                 });
 
-                this.subtotal = durationToString(data.subtotal_duration);
-                this.total = durationToString(data.total_duration);
+                this.subtotal = this.durationToString(data.subtotal_duration);
+                this.total = this.durationToString(data.total_duration);
             });
         },
         getReport() {

--- a/timestrap/static_src/components/timer.vue
+++ b/timestrap/static_src/components/timer.vue
@@ -89,7 +89,7 @@ export default {
                 user: this.entry.user,
                 project: this.entry.project,
                 note: this.entry.note,
-                duration: secondsToDurationString(this.total)
+                duration: this.secondsToString(this.total)
             };
             this.$quickFetch(this.entry.url, 'put', body).then(data => {
                 if (data.id) {
@@ -97,7 +97,7 @@ export default {
                     this.reset();
                 }
             }).catch(error => console.log(error));
-        },
+        }
     },
     created() {
         this.bus.$on('timerToggle', function(entry) {

--- a/timestrap/static_src/components/timer.vue
+++ b/timestrap/static_src/components/timer.vue
@@ -39,7 +39,10 @@
 
 
 <script>
+const DurationFormatter = require('../mixins/durationformatter');
+
 export default {
+    mixins: [ DurationFormatter ],
     data() {
         return {
             running: false,
@@ -106,7 +109,7 @@ export default {
                 this.entry = entry;
                 // Entry's duration should be in _decimal_ format.
                 if (entry.duration && typeof entry.duration === 'number') {
-                    this.total = durationToSeconds(entry.duration);
+                    this.total = this.durationToSeconds(entry.duration);
                 }
             }
             this.toggle();

--- a/timestrap/static_src/components/timesheet.vue
+++ b/timestrap/static_src/components/timesheet.vue
@@ -133,11 +133,13 @@
 
 <script>
 const Datepicker = require('./datepicker.vue');
+const DurationFormatter = require('../mixins/durationformatter');
 const Entry = require('./entry.vue');
 const Pager = require('./pager.vue');
 const Select2 = require('./select2.vue');
 
 export default {
+    mixins: [ DurationFormatter ],
     data() {
         return {
             entries: null,
@@ -181,8 +183,8 @@ export default {
                     });
                 });
 
-                this.subtotal = durationToString(data.subtotal_duration);
-                this.total = durationToString(data.total_duration);
+                this.subtotal = this.durationToString(data.subtotal_duration);
+                this.total = this.durationToString(data.total_duration);
             });
         },
         submitEntry(e) {

--- a/timestrap/static_src/mixins/durationformatter.js
+++ b/timestrap/static_src/mixins/durationformatter.js
@@ -5,7 +5,7 @@ module.exports = {
             if (typeof(duration) === 'number') {
                 let hours = Math.floor(duration);
                 let minutes = Math.round((duration - hours) * 60);
-                duration = hours + ':' + pad(minutes);
+                duration = hours + ':' + ('00' + minutes).slice(-2);
             }
             return duration;
         },
@@ -23,7 +23,7 @@ module.exports = {
             if (typeof(duration) === 'number') {
                 let hours = Math.floor(duration / 3600);
                 let minutes = Math.floor(duration % 3600 / 60);
-                duration = hours + ':' + pad(minutes);
+                duration = hours + ':' + ('00' + minutes).slice(-2);
             }
             return duration;
         }

--- a/timestrap/static_src/mixins/durationformatter.js
+++ b/timestrap/static_src/mixins/durationformatter.js
@@ -1,11 +1,20 @@
 module.exports = {
     methods: {
         // Convert a decimal duration (0.0) to a string (0:00).
-        durationToString: function (duration) {
+        durationToString: function(duration) {
             if (typeof(duration) === 'number') {
                 let hours = Math.floor(duration);
                 let minutes = Math.round((duration - hours) * 60);
                 duration = hours + ':' + pad(minutes);
+            }
+            return duration;
+        },
+        // Convert a decimal duration (0.0) duration to a number (0) of seconds.
+        durationToSeconds: function(duration) {
+            if (typeof(duration) === 'number') {
+                let hours = Math.floor(duration);
+                let minutes = Math.round((duration - hours) * 60);
+                duration = hours * 3600 + minutes * 60;
             }
             return duration;
         }

--- a/timestrap/static_src/mixins/durationformatter.js
+++ b/timestrap/static_src/mixins/durationformatter.js
@@ -17,6 +17,15 @@ module.exports = {
                 duration = hours * 3600 + minutes * 60;
             }
             return duration;
+        },
+        // Convert a number (0) of seconds to a string (0:00).
+        secondsToString: function(duration) {
+            if (typeof(duration) === 'number') {
+                let hours = Math.floor(duration / 3600);
+                let minutes = Math.floor(duration % 3600 / 60);
+                duration = hours + ':' + pad(minutes);
+            }
+            return duration;
         }
     }
 };

--- a/timestrap/static_src/mixins/durationformatter.js
+++ b/timestrap/static_src/mixins/durationformatter.js
@@ -1,0 +1,13 @@
+module.exports = {
+    methods: {
+        // Convert a decimal duration (0.0) to a string (0:00).
+        durationToString: function (duration) {
+            if (typeof(duration) === 'number') {
+                let hours = Math.floor(duration);
+                let minutes = Math.round((duration - hours) * 60);
+                duration = hours + ':' + pad(minutes);
+            }
+            return duration;
+        }
+    }
+};

--- a/timestrap/static_src/plugins/permissions.js
+++ b/timestrap/static_src/plugins/permissions.js
@@ -8,6 +8,6 @@ module.exports = {
                 perms[data[i].codename] = data[i];
             }
             Vue.prototype.$perms = perms;
-        }).catch(error => console.log(error))
+        }).catch(error => console.error(error));
     }
 };

--- a/timestrap/static_src/plugins/quickfetch.js
+++ b/timestrap/static_src/plugins/quickfetch.js
@@ -19,13 +19,13 @@ module.exports = {
             }).then(function(response) {
                 let result = null;
                 switch (response.status) {
-                    case 200:  // HTTP_200_OK
-                    case 201:  // HTTP_201_CREATED
-                        result = response.json();
-                        break;
-                    default:
-                        result = response;
-                        break;
+                case 200:  // HTTP_200_OK
+                case 201:  // HTTP_201_CREATED
+                    result = response.json();
+                    break;
+                default:
+                    result = response;
+                    break;
                 }
                 Vue.prototype.bus.$emit('block-during-fetch', false);
                 return result;

--- a/timestrap/static_src/scripts/utils.js
+++ b/timestrap/static_src/scripts/utils.js
@@ -1,8 +1,0 @@
-// Append number with 0 if there is only 1 digit
-function pad(num) {
-    num = num.toString();
-    if (num.length === 1) {
-        num = '0' + num;
-    }
-    return num;
-}

--- a/timestrap/static_src/scripts/utils.js
+++ b/timestrap/static_src/scripts/utils.js
@@ -6,14 +6,3 @@ function pad(num) {
     }
     return num;
 }
-
-
-// Convert a number (0) of seconds to a string (0:00).
-function secondsToDurationString(duration) {
-    if (typeof(duration) === 'number') {
-        let hours = Math.floor(duration / 3600);
-        let minutes = Math.floor(duration % 3600 / 60);
-        duration = hours + ':' + pad(minutes);
-    }
-    return duration;
-}

--- a/timestrap/static_src/scripts/utils.js
+++ b/timestrap/static_src/scripts/utils.js
@@ -8,17 +8,6 @@ function pad(num) {
 }
 
 
-// Convert a decimal duration (0.0) to a string (0:00).
-function durationToString(duration) {
-    if (typeof(duration) === 'number') {
-        let hours = Math.floor(duration);
-        let minutes = Math.round((duration - hours) * 60);
-        duration = hours + ':' + pad(minutes);
-    }
-    return duration;
-}
-
-
 // Convert a decimal duration (0.0) duration to a number (0) of seconds.
 function durationToSeconds(duration) {
     if (typeof(duration) === 'number') {

--- a/timestrap/static_src/scripts/utils.js
+++ b/timestrap/static_src/scripts/utils.js
@@ -8,17 +8,6 @@ function pad(num) {
 }
 
 
-// Convert a decimal duration (0.0) duration to a number (0) of seconds.
-function durationToSeconds(duration) {
-    if (typeof(duration) === 'number') {
-        let hours = Math.floor(duration);
-        let minutes = Math.round((duration - hours) * 60);
-        duration = hours * 3600 + minutes * 60;
-    }
-    return duration;
-}
-
-
 // Convert a number (0) of seconds to a string (0:00).
 function secondsToDurationString(duration) {
     if (typeof(duration) === 'number') {


### PR DESCRIPTION
:x: `utils.js` :tada: 

Caveat - we can probably still improve on how we manipulate duration information - preferably with less calculation (and potential for floating point issues?) in JS. :heavy_multiplication_x: :heavy_plus_sign: :heavy_division_sign: :heavy_minus_sign: :gun:

Something I learned a bit about but didn't end up using here - [VueJS computed properties](https://vuejs.org/v2/guide/computed.html). I'm sure these will come in handy at some point.