### PR TITLE
Model and tests clean up for conf app

### DIFF
--- a/conf/admin.py
+++ b/conf/admin.py
@@ -32,6 +32,7 @@ class SitePermissionInline(admin.StackedInline):
 
 
 class SitePermissionUserAdmin(UserAdmin):
+    UserAdmin.list_filter += ('sitepermission__sites',)
     inlines = [
         SitePermissionInline,
     ]

--- a/conf/backends.py
+++ b/conf/backends.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.contrib import messages
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import PermissionDenied
 
@@ -21,7 +22,10 @@ class SitePermissionBackend(ModelBackend):
             if site in user.sitepermission.sites.all():
                 return user
             else:
-                '''TODO: Handle in UI with a more verbose message.'''
+                messages.error(request,
+                               'This account does not have permission to log '
+                               'in to {}.'.format(request.site),
+                               'no_sitepermission')
                 raise PermissionDenied
 
     def get_user(self, user_id):

--- a/conf/models.py
+++ b/conf/models.py
@@ -13,8 +13,12 @@ class Conf(models.Model):
                                 on_delete=models.CASCADE)
     color = models.CharField(max_length=5, blank=True)
 
+    class Meta:
+        verbose_name = 'Configuration'
+        verbose_name_plural = 'Configuration'
+
     def __str__(self):
-        return 'Configuration'
+        return 'Configuration for {}'.format(self.site.name)
 
 
 @receiver(post_save, sender=Site)

--- a/conf/tests/tests.py
+++ b/conf/tests/tests.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+
+from ..models import Conf, Site, SitePermission
+
+
+@override_settings(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+class ConfTestCase(TestCase):
+    def setUp(self):
+        pass
+
+    def test_conf_created(self):
+        site = Site.objects.create(domain='test.site', name='Test Site')
+        self.assertIsInstance(site.conf, Conf)
+
+
+class SitePermissionTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user('Test User', 'test@user.com',
+                                             'test')
+        Site.objects.create(domain='test1.site', name='Test Site 1')
+        Site.objects.create(domain='test2.site', name='Test Site 2')
+
+    def test_sitepermission_created(self):
+        site_permission = SitePermission.objects.create(user=self.user)
+        self.assertIsInstance(site_permission, SitePermission)
+
+    def test_sitepermission_sites_added(self):
+        site_permission = SitePermission.objects.create(user=self.user)
+        site_permission.sites = Site.objects.all()
+        site_permission.save()
+        self.assertQuerysetEqual(site_permission.sites.all(),
+                                 map(repr, Site.objects.all()))

--- a/core/admin.py
+++ b/core/admin.py
@@ -30,7 +30,7 @@ class EntryAdmin(admin.ModelAdmin):
             'fields': ('date', 'duration',)
         }),
         ('Extra', {
-            'fields': ('note',)
+            'fields': ('note', 'site',)
         }),
     )
 
@@ -46,7 +46,7 @@ class EntryResource(resources.ModelResource):
 class InvoiceAdmin(admin.ModelAdmin):
     list_display = ('client', 'created', 'paid', 'transaction_id',)
     list_editable = ('paid', 'transaction_id',)
-    list_filter = ('client', 'paid', 'site',)
+    list_filter = ('client', 'paid',)
     search_fields = ('client', 'transaction_id',)
     filter_horizontal = ('entries',)
 

--- a/core/admin.py
+++ b/core/admin.py
@@ -5,30 +5,22 @@ from django.contrib import admin
 
 from import_export import resources
 
-from .models import Client, Project, Entry, Invoice
+from .models import Client, Entry, Invoice, Project, Task
 
 
 @admin.register(Client)
 class ClientAdmin(admin.ModelAdmin):
     list_display = ('name', 'invoice_email', 'payment_id', 'archive',)
     list_editable = ('archive',)
-    list_filter = ('archive',)
+    list_filter = ('archive', 'sites')
     search_fields = ('name',)
-
-
-@admin.register(Project)
-class ProjectAdmin(admin.ModelAdmin):
-    list_display = ('name', 'client', 'archive',)
-    list_editable = ('archive',)
-    list_filter = ('client', 'archive',)
-    search_fields = ('name', 'client',)
 
 
 @admin.register(Entry)
 class EntryAdmin(admin.ModelAdmin):
     list_display = ('project', 'user', 'date', 'duration',)
     list_editable = ('date', 'duration',)
-    list_filter = ('project', 'project__client', 'user', 'date',)
+    list_filter = ('project', 'project__client', 'user', 'date', 'site',)
     search_fields = ('project', 'project__client', 'user', 'note',)
     fieldsets = (
         (None, {
@@ -54,6 +46,21 @@ class EntryResource(resources.ModelResource):
 class InvoiceAdmin(admin.ModelAdmin):
     list_display = ('client', 'created', 'paid', 'transaction_id',)
     list_editable = ('paid', 'transaction_id',)
-    list_filter = ('client', 'paid',)
+    list_filter = ('client', 'paid', 'site',)
     search_fields = ('client', 'transaction_id',)
     filter_horizontal = ('entries',)
+
+
+@admin.register(Project)
+class ProjectAdmin(admin.ModelAdmin):
+    list_display = ('name', 'client', 'archive',)
+    list_editable = ('archive',)
+    list_filter = ('client', 'archive',)
+    search_fields = ('name', 'client',)
+
+
+@admin.register(Task)
+class TaskAdmin(admin.ModelAdmin):
+    list_display = ('name', 'hourly_rate',)
+    list_filter = ('sites',)
+    search_fields = ('name',)

--- a/core/models.py
+++ b/core/models.py
@@ -135,7 +135,8 @@ class Entry(models.Model):
     def save(self, *args, **kwargs):
         if not self.date:
             self.date = date.today()
-        self.site = Site.objects.get(id=current_site_id())
+        if not self.site:
+            self.site = Site.objects.get(id=current_site_id())
         super(Entry, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -78,6 +78,15 @@ class ClientTestCase(TestCase):
         client = Client.objects.get(name='Юникод')
         self.assertEqual(client.name, 'Юникод')
 
+    def test_client_site_relationship(self):
+        Site.objects.create(domain='test.site', name='Test Site')
+        client = Client.objects.create(name='Client on time.strap')
+        self.assertEqual(client.sites.get().name, 'Timestrap')
+        client = Client.objects.create(name='Client on test.site')
+        client.sites = Site.objects.filter(domain='test.site')
+        client.save()
+        self.assertEqual(client.sites.get().name, 'Test Site')
+
 
 class ProjectTestCase(TestCase):
     def setUp(self):
@@ -139,6 +148,14 @@ class EntryTestCase(TestCase):
             duration__lte=timedelta(hours=1, minutes=30)
         )
         self.assertEqual(len(entries), 1)
+
+    def test_entry_site_relationship(self):
+        site = Site.objects.create(domain='test.site', name='Test Site')
+        entry = Entry.objects.get(duration=timedelta(hours=1))
+        self.assertEqual(entry.site.name, 'Timestrap')
+        entry.site = site
+        entry.save()
+        self.assertEqual(entry.site.name, 'Test Site')
 
     def test_parse_duration(self):
         duration = parse_duration('3.25')

--- a/gulpfile.js/tasks/testing.js
+++ b/gulpfile.js/tasks/testing.js
@@ -30,7 +30,7 @@ gulp.task('coverage', (cb) => {
             'run',
             'coverage',
             'run',
-            '--source=core,api',
+            '--source=conf,core,api',
             'manage.py',
             'test'
         ],

--- a/timestrap/templates/registration/login.html
+++ b/timestrap/templates/registration/login.html
@@ -24,19 +24,26 @@
                         <a href="https://github.com/overshard/timestrap">documentation</a>.</p>
                     </div>
 
-                    {% if form.errors %}
+                    {% if messages %}
+                        {% for message in messages %}
+                            {% if message.extra_tags == 'no_sitepermission' %}
+                                <div class="alert alert-warning mb-5">
+                                    <p class="mb-0"><strong>Warning!</strong>
+                                    {{ message }}</p>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                    {% elif form.errors %}
                         <div class="alert alert-danger mb-5">
                             <p class="mb-0"><strong>Oh snap!</strong> Your
                             username and password didn't match. Please try
                             again.</p>
                         </div>
-                    {% endif %}
-
-                    {% if next and user.is_authenticated %}
+                    {% elif next and user.is_authenticated %}
                         <div class="alert alert-warning mb-4">
                             <p class="mb-0"><strong>Warning!</strong> Your
                             account doesn't have access to this page. To
-                            proceed, please login with an account that has
+                            proceed, please log in with an account that has
                             access.</p>
                         </div>
                     {% endif %}


### PR DESCRIPTION
Mostly cleaning up `conf` models and getting sites hooked in to `core` models. Also adds tests for `conf` and a few other random things.

This basically finishes #76, but we still need to come with at least one configuration option, hah. Right now I only have an unused "color" field in there. What should be configurable per site?