### PR TITLE
[Fix] add default auth classes to activate token authentication

### DIFF
--- a/timestrap/settings/base.py
+++ b/timestrap/settings/base.py
@@ -120,4 +120,9 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 100,
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "UNICODE_JSON": False,
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.BasicAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
+    ],
 }


### PR DESCRIPTION
This fixes an issue I had before when trying to authenticate with `Authorization: Token <my-token>` with a token retrieved via the API. Before, I got a `401 Unauthorized` with the following body:
```
{
  "detail": "Authentication credentials were not provided."
}
```