### PR TITLE
node-sass -> sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint-plugin-vue": "^5.2.2",
     "file-loader": "^3.0.1",
     "mini-css-extract-plugin": "^0.6.0",
-    "node-sass": "^4.12.0",
+    "sass": "^1.52.3",
     "sass-loader": "^7.1.0",
     "vue-eslint-parser": "^6.0.4",
     "vue-loader": "^15.7.0",


### PR DESCRIPTION
This tweak seemed to be required for me to get Timestrap's Docker to build successfully again after Heroku stopped working.